### PR TITLE
Correction export creds minio

### DIFF
--- a/src/js/components/mon-compte/export-credentials-minio.js
+++ b/src/js/components/mon-compte/export-credentials-minio.js
@@ -30,11 +30,11 @@ fs = s3fs.S3FileSystem(client_kwargs={'endpoint_url': 'http://'+'${c.AWS_S3_ENDP
 		label: 'Environment variables',
 		fileName: '.bashrc',
 		text: (c) => `
-export AWS_ACCESS_KEY_ID = ${c.AWS_ACCESS_KEY_ID}
-export AWS_SECRET_ACCESS_KEY = ${c.AWS_SECRET_ACCESS_KEY}
-export AWS_DEFAULT_REGION = ${c.AWS_DEFAULT_REGION}
-export AWS_SESSION_TOKEN = ${c.AWS_SESSION_TOKEN}
-export AWS_S3_ENDPOINT = ${c.AWS_S3_ENDPOINT}
+export AWS_ACCESS_KEY_ID= ${c.AWS_ACCESS_KEY_ID}
+export AWS_SECRET_ACCESS_KEY= ${c.AWS_SECRET_ACCESS_KEY}
+export AWS_DEFAULT_REGION= ${c.AWS_DEFAULT_REGION}
+export AWS_SESSION_TOKEN= ${c.AWS_SESSION_TOKEN}
+export AWS_S3_ENDPOINT= ${c.AWS_S3_ENDPOINT}
 		`,
 	},
 	{

--- a/src/js/components/mon-compte/export-credentials-minio.js
+++ b/src/js/components/mon-compte/export-credentials-minio.js
@@ -17,6 +17,33 @@ library("aws.s3")
 bucketlist()`,
 	},
 	{
+		id: 'r_bis',
+		label: 'R (paws)',
+		fileName: 'credentials.R',
+		text: (c) =>
+			`
+install.packages("paws", repos = "https://cloud.R-project.org")
+
+Sys.setenv("AWS_ACCESS_KEY_ID" = "${c.AWS_ACCESS_KEY_ID}",
+           "AWS_SECRET_ACCESS_KEY" = "${c.AWS_SECRET_ACCESS_KEY}",
+           "AWS_DEFAULT_REGION" = "${c.AWS_DEFAULT_REGION}",
+           "AWS_SESSION_TOKEN" = "${c.AWS_SESSION_TOKEN}",
+           "AWS_S3_ENDPOINT"= "${c.AWS_S3_ENDPOINT}")
+
+library("paws")
+minio <- paws::s3(config = list(
+	credentials = list(
+	  creds = list(
+		access_key_id = Sys.getenv("AWS_ACCESS_KEY_ID"),
+		secret_access_key = Sys.getenv("AWS_SECRET_ACCESS_KEY"),
+		session_token = Sys.getenv("AWS_SESSION_TOKEN")
+	  )),
+	endpoint = paste0("https://", Sys.getenv("AWS_S3_ENDPOINT")),
+	region = Sys.getenv("AWS_DEFAULT_REGION")))
+  
+  minio$list_buckets()`,
+	},
+	{
 		id: 'python',
 		label: 'Python (s3fs)',
 		fileName: 'credentials.py',

--- a/src/js/components/mon-compte/export-credentials-minio.js
+++ b/src/js/components/mon-compte/export-credentials-minio.js
@@ -41,7 +41,7 @@ minio <- paws::s3(config = list(
 	endpoint = paste0("https://", Sys.getenv("AWS_S3_ENDPOINT")),
 	region = Sys.getenv("AWS_DEFAULT_REGION")))
   
-  minio$list_buckets()`,
+minio$list_buckets()`,
 	},
 	{
 		id: 'python',


### PR DESCRIPTION
This PR for two reasons:

- the bash file for exporting environment variables regarding connection to Minio can't work due to an extra space before the `=` signe;
- the `aws.S3` method for connecting to Minio with R does not work, for a reason I can't still figure out - I actually thought the library was not maintained and switched to `paws` for which I propose to set up a working code - tested on RStudio, works just fine.