### PR TITLE
Add monitoring. Fix #131

### DIFF
--- a/src/js/components/my-service/service.tsx
+++ b/src/js/components/my-service/service.tsx
@@ -44,6 +44,7 @@ const MyService = ({ serviceId }: Props) => {
 			<Toolbar
 				handleRefresh={() => refreshData()}
 				handleDelete={() => handleDelete()}
+				monitoringUrl={service?.monitoring?.url}
 			/>
 			{loading ? <Loader em={18} /> : <ServiceDetails service={service} />}
 		</div>

--- a/src/js/components/my-service/toolbar.tsx
+++ b/src/js/components/my-service/toolbar.tsx
@@ -6,9 +6,10 @@ import D from 'js/i18n';
 interface Props {
 	handleDelete?: () => void;
 	handleRefresh?: () => void;
+	monitoringUrl?: string;
 }
 
-const Toolbar = ({ handleDelete, handleRefresh }: Props) => {
+const Toolbar = ({ handleDelete, handleRefresh, monitoringUrl }: Props) => {
 	const [dialog, setDialog] = useState(false);
 	const wantDelete = () => {
 		setDialog(true);
@@ -22,7 +23,11 @@ const Toolbar = ({ handleDelete, handleRefresh }: Props) => {
 	};
 	return (
 		<Paper className="onyxia-toolbar" elevation={1}>
-			<Actions handleDelete={wantDelete} handleRefresh={handleRefresh} />
+			<Actions
+				handleDelete={wantDelete}
+				handleRefresh={handleRefresh}
+				monitoringUrl={monitoringUrl}
+			/>
 			<Dialog
 				open={dialog}
 				title={D.myServiceDialogTitle}
@@ -36,7 +41,7 @@ const Toolbar = ({ handleDelete, handleRefresh }: Props) => {
 	);
 };
 
-const Actions = ({ handleDelete, handleRefresh }) => (
+const Actions = ({ handleDelete, handleRefresh, monitoringUrl }) => (
 	<>
 		{handleRefresh && (
 			<Tooltip title="Refresh">
@@ -47,6 +52,18 @@ const Actions = ({ handleDelete, handleRefresh }) => (
 					onClick={handleRefresh}
 				>
 					<Icon>refresh</Icon>
+				</Fab>
+			</Tooltip>
+		)}
+		{monitoringUrl && (
+			<Tooltip title="Monitoring">
+				<Fab
+					color="secondary"
+					aria-label="monitor"
+					classes={{ root: 'bouton' }}
+					onClick={() => window.open(monitoringUrl)}
+				>
+					<Icon>equalizer</Icon>
 				</Fab>
 			</Tooltip>
 		)}

--- a/src/js/model/Service.ts
+++ b/src/js/model/Service.ts
@@ -21,6 +21,9 @@ export interface Service {
 	env?: object;
 	tasks?: Task[];
 	events?: Event[];
+	monitoring?: {
+		url: string;
+	};
 }
 
 export enum ServiceType {


### PR DESCRIPTION
Add monitoring (requires API version `0.2.2+`).  
If API supports it, display a button on service's page to open monitoring.