### PR TITLE
Correcting typography in size label for 'Mes-fichiers'

### DIFF
--- a/src/js/components/mes-fichiers/navigation/my-file/details.component.js
+++ b/src/js/components/mes-fichiers/navigation/my-file/details.component.js
@@ -28,7 +28,7 @@ const Details = ({ file, statusPolicy }) => (
 
 const getSizeLabel = (size) =>
 	size > 1000000000
-		? `${(size / Math.pow(1024, 2)).toFixed(3)} go`
+		? `${(size / Math.pow(1024, 3)).toFixed(2)} go`
 		: size > 1000000
 		? `${Math.round(size / Math.pow(1024, 2)).toFixed(2)} mo`
 		: `${Math.round(size / 1024).toFixed(2)} ko`;


### PR DESCRIPTION
Small typo in the display of size.

e.g.
![Capture](https://user-images.githubusercontent.com/22787340/95582478-fc2b2900-0a3a-11eb-9096-e11665d3db06.PNG)
