### PR TITLE
Dark mode switch corrections

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,8 +65,7 @@
         "memoizee": "^0.4.15",
         "powerhooks": "^0.6.2",
         "ts-toolbelt": "^9.6.0",
-        "tsafe": "^0.4.1",
-        "framer-motion": "^4.1.17"
+        "tsafe": "^0.4.1"
     },
     "devDependencies": {
         "@material-ui/core": "^4.12.1",

--- a/src/DarkModeSwitch.tsx
+++ b/src/DarkModeSwitch.tsx
@@ -1,14 +1,20 @@
 import { memo } from "react";
 import { useConstCallback } from "powerhooks/useConstCallback";
-import { useNamedState } from "powerhooks";
 import { useIsDarkModeEnabled } from "./lib/index";
 import DarkModeIcon from "@material-ui/icons/Brightness4";
 import LightModeIcon from "@material-ui/icons/Brightness7";
-import { motion } from "framer-motion";
-import type { Transition } from "framer-motion";
 import { createIcon } from "./Icon";
 import { createIconButton } from "./IconButton";
 import type { IconProps } from "./Icon";
+import { makeStyles } from "./lib/ThemeProvider";
+
+const useStyles = makeStyles()(theme => ({
+    "root": {
+        "transition": "transform 500ms",
+        "transform": `rotate(${theme.isDarkModeEnabled ? 180 : 0}deg)`,
+        "transitionTimingFunction": "cubic-bezier(.34,1.27,1,1)",
+    },
+}));
 
 const { Icon } = createIcon({
     "darkModeIcon": DarkModeIcon,
@@ -23,33 +29,22 @@ export type DarkModeSwitchProps = {
     size?: IconProps["size"];
 };
 
-const transition: Transition = { "duration": 0.5 };
-
 export const DarkModeSwitch = memo((props: DarkModeSwitchProps) => {
     const { className, size } = props;
     const { isDarkModeEnabled, setIsDarkModeEnabled } = useIsDarkModeEnabled();
-    const { motionProps, setMotionProps } = useNamedState("motionProps", {
-        "rotate": 0,
-    });
 
     const onClick = useConstCallback(() => {
         setIsDarkModeEnabled(!isDarkModeEnabled);
-        setMotionProps({
-            "rotate": motionProps.rotate === 0 ? 180 : 0,
-        });
     });
 
+    const { classes, cx } = useStyles();
+
     return (
-        <motion.div
-            className={className}
-            animate={motionProps}
-            transition={transition}
-        >
-            <IconButton
-                onClick={onClick}
-                size={size}
-                iconId={isDarkModeEnabled ? "lightModeIcon" : "darkModeIcon"}
-            />
-        </motion.div>
+        <IconButton
+            className={cx(classes.root, className)}
+            onClick={onClick}
+            size={size}
+            iconId={isDarkModeEnabled ? "lightModeIcon" : "darkModeIcon"}
+        />
     );
 });


### PR DESCRIPTION
the Icon was wrapped in a div which means that it was the wrapper that was rotating rather than the Icon its self.
It was working by coinsidence. Sorry.
I used a css transition and a cubic-bezier function to give a bit of bounce and to get rid of framer-motion as dependency, whitch I think isnt nececary for this use case. 