### PR TITLE
Allow to change the aria label in the dark mode switch.

### DIFF
--- a/src/DarkModeSwitch.tsx
+++ b/src/DarkModeSwitch.tsx
@@ -1,6 +1,6 @@
 import { memo } from "react";
 import { useConstCallback } from "powerhooks/useConstCallback";
-import { useIsDarkModeEnabled } from "./lib/index";
+import { useIsDarkModeEnabled } from "./lib";
 import DarkModeIcon from "@mui/icons-material/Brightness4";
 import LightModeIcon from "@mui/icons-material/Brightness7";
 import { createIcon } from "./Icon";
@@ -19,10 +19,11 @@ export type DarkModeSwitchProps = {
     className?: string;
     /** Default: default */
     size?: IconProps["size"];
+    ariaLabel?: string;
 };
 
 export const DarkModeSwitch = memo((props: DarkModeSwitchProps) => {
-    const { className, size } = props;
+    const { className, size, ariaLabel } = props;
     const { isDarkModeEnabled, setIsDarkModeEnabled } = useIsDarkModeEnabled();
 
     const onClick = useConstCallback(() => {
@@ -37,7 +38,7 @@ export const DarkModeSwitch = memo((props: DarkModeSwitchProps) => {
             onClick={onClick}
             size={size}
             iconId={isDarkModeEnabled ? "lightModeIcon" : "darkModeIcon"}
-            aria-label="Dark mode switch"
+            aria-label={ariaLabel ?? "Dark mode switch"}
         />
     );
 });


### PR DESCRIPTION
Feedback from the RGAA 4.1 accessibility audit.
The criterion 11.9 "In each form, is the title of each button relevant (except in special cases)?" is not respected due to the label "Dark mode switch" in English even when the page is in another language.